### PR TITLE
Add NMF to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,6 @@ Imports:
     plyr,
     magrittr,
     pamr,
-    RColorBrewer
+    RColorBrewer,
+    NMF
 RoxygenNote: 6.0.1


### PR DESCRIPTION
I noticed that NMF is a required package to run the pipeline.  This line here will stop execution if NMF is not installed:

https://github.com/syspremed/polyClustR/blob/94a7fbc378e18ccf86ca91863b4faaac8e779724/R/polyClustRPackage.R#L44

However, the NMF package isn't currently included in the `Imports` section of the `NAMESPACE` file, so you can successfully install the polyClustR package without having NMF installed.  

This change adds NMF in to that section so that the NMF package becomes a requirement that is checked at install time.